### PR TITLE
added support for project specific settings

### DIFF
--- a/goOracle.py
+++ b/goOracle.py
@@ -207,11 +207,15 @@ def get_setting(key, default=None):
     default setting. If neither are set the 'default' value passed in is returned.
     """
 
-    val = sublime.load_settings("User.sublime-settings").get(key)
+    project_plugin_settings = sublime.active_window().active_view().settings().get('GoOracle.sublime-settings', {})
+    val = project_plugin_settings.get(key)
+    if not val:
+        val = sublime.load_settings("User.sublime-settings").get(key)
     if not val:
         val = sublime.load_settings("Default.sublime-settings").get(key)
     if not val:
-        val = default
+        val = default    
+
     return val
 
 def get_output_view(window):


### PR DESCRIPTION
This allows you to have project specific settings for GoOracle, so you can set the settings according to your project (like if you use Godeps and need to set a specific GOPATH, and to set the scope correctly).
