### PR TITLE
add support for windows

### DIFF
--- a/GoOracleResults.tmLanguage
+++ b/GoOracleResults.tmLanguage
@@ -23,7 +23,7 @@
     <!-- plain output line reference -->
     <dict>
       <key>match</key>
-      <string>^([^:]*:[0-9]+.[0-9]+)[-:]</string>
+      <string>^(.+\.go:[0-9]+.[0-9]+)[-:]</string>
       <key>captures</key>
       <dict>
         <key>1</key>


### PR DESCRIPTION
Hi @waigani ,

Follow https://github.com/waigani/GoOracle/issues/10, I added the support for windows. Codes are simple, just to let it work, and not affect OSX/linux part. Modified places:
- stdout encoding is changed to 'cp936' not 'utf-8' under windows
- Regex for auto-locating oracle output message in files is fixed: Windows path includes `:`, so the regex can't use `[^:]+`, I changed it to `.+\.go`
- Regex for matching file path in oracle result syntax highlight file is fixed: the same reason as above
- Command string for Windows is added: Change `export` to `SET` for GOPATH and GOROOT env variables 
- GOPATH supports multiple paths under Windows: The GOPATH environment variable under windows need follow the format as: `"path1";"path2";...`

After this change, the GOPATH settings support multiple paths, for example:

``` json
"GoOracle":
{
    "env":
    {
        "GOPATH": "D:\\Codes\\gocode\\huaweitech;D:\\Codes\\gocode\\huaweitech\\src\\github.com\\cloudfoundry\\cli/Godeps/_workspace",
        "GOROOT": "D:\\Tools\\Golang",
    },
    // other settings
}
```

Hope it could help guys who have the same requirements with me. So please check it if you have time :)
