### PR TITLE
Update README oracle import path

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Dependencies
 ------------
 GoOracle relies on the oracle tool. You must install it in order for GoOracle to work. Run the following on your command line:
 
-`go get code.google.com/p/go.tools/cmd/oracle`
+`go get golang.org/x/tools/cmd/oracle`
 
 
 About Go Oracle


### PR DESCRIPTION
With the move to Github, the Go import paths have changed.
https://groups.google.com/forum/#!topic/golang-nuts/eD8dh3T9yyA
